### PR TITLE
Fix NPE

### DIFF
--- a/core/src/main/java/com/devexperts/dlcheck/LockGraph.java
+++ b/core/src/main/java/com/devexperts/dlcheck/LockGraph.java
@@ -446,7 +446,7 @@ class LockGraph {
                 }
             }
         }
-        return null;
+        return new ArrayList<>();
     }
 
     void dump() {


### PR DESCRIPTION
If method [LockGraph.shortestPath](https://github.com/Devexperts/dlcheck/blob/master/core/src/main/java/com/devexperts/dlcheck/LockGraph.java#L449) returns null, it's lead to NPE in method [LockGraph.publishPotentialDeadlockIfNeeded](https://github.com/Devexperts/dlcheck/blob/master/core/src/main/java/com/devexperts/dlcheck/LockGraph.java#L387).